### PR TITLE
Store username in Firestore

### DIFF
--- a/ui/providers/Username.tsx
+++ b/ui/providers/Username.tsx
@@ -1,24 +1,62 @@
 import { useAsyncStorage } from "@react-native-async-storage/async-storage";
 import { useCallback, useEffect, useState } from "react";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { firestore, isFirebaseConfigured } from "@/config/firebase";
+import { useUserId } from "@/providers/Auth";
 
 const STORAGE_KEY = "@modi/username";
 
 export function useUsername() {
   const { getItem, setItem } = useAsyncStorage(STORAGE_KEY);
   const [username, setUsernameState] = useState("");
+  const userId = useUserId();
 
   useEffect(() => {
-    getItem().then((val) => {
-      if (val) setUsernameState(val);
-    });
-  }, [getItem]);
+    async function fetchUsername() {
+      let cloudName: string | null = null;
+
+      if (isFirebaseConfigured && userId) {
+        try {
+          const userRef = doc(firestore, `users/${userId}`);
+          const snap = await getDoc(userRef);
+          if (snap.exists()) {
+            const data = snap.data() as { username?: string };
+            if (data.username) {
+              cloudName = data.username;
+            }
+          }
+        } catch (err) {
+          console.error("Failed to fetch username from Firestore", err);
+        }
+      }
+
+      if (cloudName) {
+        setUsernameState(cloudName);
+        setItem(cloudName);
+      } else {
+        const val = await getItem();
+        if (val) setUsernameState(val);
+      }
+    }
+
+    fetchUsername();
+  }, [getItem, setItem, userId]);
 
   const setUsername = useCallback(
-    (name: string) => {
+    async (name: string) => {
       setUsernameState(name);
       setItem(name);
+
+      if (isFirebaseConfigured && userId) {
+        try {
+          const userRef = doc(firestore, `users/${userId}`);
+          await setDoc(userRef, { username: name }, { merge: true });
+        } catch (err) {
+          console.error("Failed to set username in Firestore", err);
+        }
+      }
     },
-    [setItem]
+    [setItem, userId]
   );
 
   return { value: username, setValue: setUsername };


### PR DESCRIPTION
## Summary
- persist usernames in Firestore using uid from Auth provider
- fall back to local storage if cloud value isn't found

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6865f11fcaf0832aac4ad19d4f8b3b0a