### PR TITLE
Fix issue #2

### DIFF
--- a/ui/elements/Button/index.tsx
+++ b/ui/elements/Button/index.tsx
@@ -43,8 +43,8 @@ const Button: React.FC<ButtonProps & TouchableOpacityProps> = ({
   const defaultStyles = useMemo<StyleProp<ViewStyle>>(
     () => ({
       backgroundColor: color ? colors[color] : undefined,
-      padding: 16,
-      paddingVertical: thin ? 6 : 16,
+      padding: 12,
+      paddingVertical: thin ? 4 : 12,
       borderRadius: 16,
       alignItems: "center",
       justifyContent: "center",
@@ -62,7 +62,9 @@ const Button: React.FC<ButtonProps & TouchableOpacityProps> = ({
       {loading ? (
         <LoadingSpinner size="large" color="white" />
       ) : title ? (
-        <Text style={titleStyle}>{title}</Text>
+        <Text numberOfLines={1} style={titleStyle}>
+          {title}
+        </Text>
       ) : (
         children
       )}

--- a/ui/elements/Text/index.tsx
+++ b/ui/elements/Text/index.tsx
@@ -12,16 +12,29 @@ interface TextProps extends React.PropsWithChildren {
 
   /** Optional override styles */
   style?: StyleProp<TextStyle>;
+
+  /** Forwarded to RN Text for truncation */
+  numberOfLines?: number;
 }
 
-const Text: React.FC<TextProps> = ({ size, children, style, color }) => {
+const Text: React.FC<TextProps> = ({
+  size,
+  children,
+  style,
+  color,
+  numberOfLines,
+}) => {
   const styles = useRef<StyleProp<TextStyle>>({
     fontSize: size || 18,
     fontFamily: fontFamilies.primary,
     color: colors[color || "white"],
   }).current;
 
-  return <RNText style={[styles, style]}>{children}</RNText>;
+  return (
+    <RNText numberOfLines={numberOfLines} style={[styles, style]}>
+      {children}
+    </RNText>
+  );
 };
 
 export default Text;

--- a/ui/screens/Lobby/Base.tsx
+++ b/ui/screens/Lobby/Base.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { KeyboardAvoidingView } from "react-native";
 
-import { InitialGameState } from "@/functions/src/types";
+import { InitialGame } from "@/functions/src/types";
 import { PlayersList } from "@/ui/components/PlayerList";
 import { Button, Container, Icon, ScreenContainer, Text } from "@/ui/elements";
 
 export interface LobbyScreenProps {
   currUserId: string;
-  game: InitialGameState;
+  game: InitialGame;
   /**
    * Typical native share interface for sharing the link to this game page.
    */
@@ -71,11 +71,10 @@ const LobbyScreen: React.FC<LobbyScreenProps> = ({
       >
         <Button
           color="red"
-          fullWidth
           onPress={onBackBtnPressed}
-          style={{ height: 64, width: 64, borderRadius: 32, marginRight: 16 }}
+          style={{ height: 48, width: 48, borderRadius: 24, marginRight: 16 }}
         >
-          <Icon name="back" size={32} color="white" />
+          <Icon name="back" size={24} color="white" />
         </Button>
 
         <Container style={{ flex: 1 }}>
@@ -83,22 +82,24 @@ const LobbyScreen: React.FC<LobbyScreenProps> = ({
             game.host === currUserId ? (
               <Button
                 color="blue"
+                fullWidth
                 onPress={onStartGameBtnPressed}
+                title="Start Game"
+                titleStyle={{ fontSize: 28 }}
                 style={{ height: 64, marginRight: 0 }}
-              >
-                <Text size={28}>Start Game</Text>
-              </Button>
+              />
             ) : (
               <Text size={28}>Waiting for host to start the game...</Text>
             )
           ) : (
             <Button
               color="blue"
+              fullWidth
               onPress={onJoinGameBtnPressed}
+              title="Join Game"
+              titleStyle={{ fontSize: 28 }}
               style={{ height: 64, marginRight: 0 }}
-            >
-              <Text size={28}>Join Game</Text>
-            </Button>
+            />
           )}
         </Container>
       </Container>

--- a/ui/screens/Lobby/Provider.tsx
+++ b/ui/screens/Lobby/Provider.tsx
@@ -5,9 +5,9 @@ import { LobbyScreenProps } from "./Base";
 const defaultContextValue: LobbyScreenProps = {
   game: {
     gameId: "Game ID",
-    gameState: "gathering-players",
+    status: "gathering-players",
     players: [],
-    playerInfo: {},
+    usernames: {},
     host: "Host ID",
   },
   currUserId: "User ID",


### PR DESCRIPTION
## Summary
- shrink default button padding and enforce single-line titles
- allow `Text` component to support `numberOfLines`
- refine lobby screen buttons for mobile layout
- update lobby provider fixture to match new game type

## Testing
- `yarn lint`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_686d2af52044832aac172d139551fd65