### PR TITLE
Add player tooltips for lives

### DIFF
--- a/ui/components/PlayerCircle.tsx
+++ b/ui/components/PlayerCircle.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+import { TouchableOpacity, ViewStyle } from "react-native";
+import { Container, Text } from "../elements";
+
+export interface PlayerCircleProps {
+  playerId: string;
+  username: string;
+  lives?: number;
+  roundState?: "pre-deal" | "playing" | "tallying";
+  style: ViewStyle;
+}
+
+export function PlayerCircle({
+  playerId,
+  username,
+  lives,
+  roundState,
+  style,
+}: PlayerCircleProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (roundState && roundState !== "playing") {
+      setOpen(true);
+    } else {
+      setOpen(false);
+    }
+  }, [roundState]);
+
+  return (
+    <TouchableOpacity
+      key={playerId}
+      onPress={() => setOpen((curr) => !curr)}
+      activeOpacity={0.8}
+      style={style}
+    >
+      <Container
+        color="gray"
+        style={{
+          padding: 8,
+          borderRadius: 25,
+          width: 50,
+          height: 50,
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Text>{username.slice(0, 2)}</Text>
+      </Container>
+      {open && lives !== undefined && (
+        <Container
+          color="gray"
+          style={{
+            position: "absolute",
+            bottom: 60,
+            left: "50%",
+            transform: [{ translateX: -40 }],
+            padding: 6,
+            borderRadius: 6,
+            alignItems: "center",
+          }}
+        >
+          <Text size={12}>{username}</Text>
+          <Text size={12}>❤️ {lives}</Text>
+        </Container>
+      )}
+    </TouchableOpacity>
+  );
+}

--- a/ui/components/PlayerList.tsx
+++ b/ui/components/PlayerList.tsx
@@ -1,12 +1,20 @@
-import { InitialGame } from "@/functions/src/types";
 import React from "react";
-import { Container, Text } from "../elements";
+import { ViewStyle } from "react-native";
+import { Container } from "../elements";
+import { PlayerCircle } from "./PlayerCircle";
+
+export interface PlayersListGame {
+  players: string[];
+  usernames: { [playerId: string]: string };
+  playerLives?: { [playerId: string]: number };
+  roundState?: "pre-deal" | "playing" | "tallying";
+}
 
 export function PlayersList(props: {
-  game: Pick<InitialGame, "players" | "usernames">;
+  game: PlayersListGame;
   currUserId: string;
 }) {
-  const { players, usernames } = props.game;
+  const { players, usernames, playerLives, roundState } = props.game;
   const { currUserId } = props;
 
   // Find the index of the current user
@@ -44,29 +52,26 @@ export function PlayersList(props: {
         const x = radius * Math.cos(angle);
         const y = radius * Math.sin(angle);
 
+        const style: ViewStyle = {
+          position: "absolute",
+          left: "50%",
+          top: "50%",
+          transform: [
+            { translateX: x - 25 },
+            { translateY: y - 25 },
+            { rotate: `${-rotationDegrees}deg` },
+          ],
+        };
+
         return (
-          <Container
+          <PlayerCircle
             key={playerId}
-            color="gray"
-            style={{
-              padding: 8,
-              borderRadius: 25,
-              width: 50,
-              height: 50,
-              position: "absolute",
-              left: "50%",
-              top: "50%",
-              transform: [
-                { translateX: x - 25 }, // -25 to center (half of width)
-                { translateY: y - 25 }, // -25 to center (half of height)
-                { rotate: `${-rotationDegrees}deg` }, // Counter-rotate to keep text upright
-              ],
-              justifyContent: "center",
-              alignItems: "center",
-            }}
-          >
-            <Text>{usernames[playerId].slice(0, 2)}</Text>
-          </Container>
+            playerId={playerId}
+            username={usernames[playerId]}
+            lives={playerLives ? playerLives[playerId] : undefined}
+            roundState={roundState}
+            style={style}
+          />
         );
       })}
     </Container>

--- a/ui/screens/Game/Playing.tsx
+++ b/ui/screens/Game/Playing.tsx
@@ -44,33 +44,6 @@ export function GamePlaying(props: { game: ActiveGame }) {
         <PlayersList game={game} currUserId={currentUserId} />
       </Container>
 
-      {/* Player Lives */}
-      <Container style={{ marginBottom: 20 }}>
-        <Text style={{ fontSize: 18, fontWeight: "bold", marginBottom: 12 }}>
-          Lives
-        </Text>
-        <Container style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
-          {game.players.map((playerId) => (
-            <Container
-              key={playerId}
-              color="blue"
-              style={{
-                padding: 8,
-                borderRadius: 8,
-                minWidth: 80,
-                alignItems: "center",
-              }}
-            >
-              <Text size={12} style={{ fontSize: 12, marginBottom: 4 }}>
-                {game.usernames[playerId]}
-              </Text>
-              <Text style={{ fontSize: 16, fontWeight: "bold" }}>
-                ❤️ {game.playerLives[playerId]}
-              </Text>
-            </Container>
-          ))}
-        </Container>
-      </Container>
 
       {/* Current Player's Card */}
       <Container


### PR DESCRIPTION
## Summary
- remove old Player Lives list from Game screen
- show tooltip with username and remaining lives when tapping player circles
- automatically show all tooltips during `pre-deal` and `tallying` phases
- refactor tooltip behavior into new `PlayerCircle` component

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_686d2d0771f8832a8cf4c0cfdd034fcd