### PR TITLE
Add share invite for game lobby

### DIFF
--- a/hooks/useShare.ts
+++ b/hooks/useShare.ts
@@ -1,0 +1,23 @@
+import * as Linking from 'expo-linking';
+import { Share } from 'react-native';
+
+/**
+ * Hook providing sharing functionality for inviting others to a game.
+ *
+ * This opens the native share sheet with a link to join the specified game.
+ */
+export function useShare() {
+  const shareGame = async (gameId: string) => {
+    try {
+      const url = Linking.createURL(`/games/${gameId}`);
+      await Share.share({
+        message: `Join my Modi game!\n${url}`,
+        url,
+      });
+    } catch (err) {
+      console.log('useShare: Error sharing game link', err);
+    }
+  };
+
+  return { shareGame };
+}

--- a/ui/screens/Game/GatheringPlayers.tsx
+++ b/ui/screens/Game/GatheringPlayers.tsx
@@ -4,6 +4,7 @@ import { useLeaveGame } from "@/hooks/useLeaveGame";
 import { useStartGame } from "@/hooks/useStartGame";
 import { useAuth } from "@/providers/Auth";
 import React from "react";
+import { useShare } from "@/hooks/useShare";
 import LobbyScreen from "../Lobby/Base";
 
 export function GatheringPlayers(props: { game: InitialGame }) {
@@ -11,12 +12,13 @@ export function GatheringPlayers(props: { game: InitialGame }) {
   const { leaveGame } = useLeaveGame();
   const { joinLobby } = useJoinLobby();
   const { startGame } = useStartGame();
+  const { shareGame } = useShare();
 
   return (
     <LobbyScreen
       game={props.game}
       currUserId={userId || ""}
-      onInviteFriendsBtnPressed={() => {}}
+      onInviteFriendsBtnPressed={() => shareGame(props.game.gameId)}
       onStartGameBtnPressed={() => startGame(props.game.gameId)}
       onJoinGameBtnPressed={() => joinLobby(props.game.gameId)}
       onBackBtnPressed={leaveGame}


### PR DESCRIPTION
## Summary
- enable sharing from the gathering players screen using new `useShare` hook

## Testing
- `yarn lint` *(fails: Internal Error about lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687039f13460832a84d818be4d56b47f