### PR TITLE
Change table center to white

### DIFF
--- a/ui/components/CardTable/index.tsx
+++ b/ui/components/CardTable/index.tsx
@@ -20,7 +20,7 @@ export function CardTable({ children, onLayout }: CardTableProps) {
 
   return (
     <Container
-      color="lightGreen"
+      color="white"
       style={{
         aspectRatio: 1,
         borderRadius: 999,


### PR DESCRIPTION
## Summary
- tweak card table to use a white background

## Testing
- `yarn lint` *(fails: expo lint didn't run)*

------
https://chatgpt.com/codex/tasks/task_e_68705e102a08832a9d42883bb0c80999