### PR TITLE
Fix initial animation value in AlertBanner

### DIFF
--- a/ui/components/AlertBanner.tsx
+++ b/ui/components/AlertBanner.tsx
@@ -26,7 +26,7 @@ const BannerRef = createRef<BannerRefType>();
 export function AlertBanner() {
   const [config, setConfig] = useState<ShowBannerConfig | null>(null);
   const [layout, setLayout] = useState<LayoutRectangle | null>(null);
-  const animation = useRef(new Animated.Value(1)).current;
+  const animation = useRef(new Animated.Value(0)).current;
   const translateY = useMemo(() => {
     return animation.interpolate({
       inputRange: [0, 1],


### PR DESCRIPTION
## Summary
- initialize AlertBanner animation at 0

## Testing
- `yarn lint`
- `yarn test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_687d72ea6c50832a95042317e09f837a