### PR TITLE
Add setPlayerOrder cloud function

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -27,4 +27,5 @@ export { leaveGame } from "./leaveGame";
 export { startGame } from "./startGame";
 export { stick } from "./stick";
 export { swapCard } from "./swapCard";
+export { setPlayerOrder } from "./setPlayerOrder";
 

--- a/functions/src/setPlayerOrder.ts
+++ b/functions/src/setPlayerOrder.ts
@@ -1,0 +1,67 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+import { InitialGame } from "./types";
+
+const db = getFirestore();
+
+export interface SetPlayerOrderRequest {
+  gameId: string;
+  players: string[];
+}
+
+export interface SetPlayerOrderResponse {
+  success: boolean;
+}
+
+export const setPlayerOrder = onCall<SetPlayerOrderRequest, Promise<SetPlayerOrderResponse>>(async (request) => {
+  const userId = request.auth?.uid;
+  if (!userId) {
+    console.error("setPlayerOrder: User is not authenticated");
+    throw new HttpsError("unauthenticated", "User is not authenticated");
+  }
+
+  const { gameId, players } = request.data;
+  if (!gameId || !players || !Array.isArray(players)) {
+    console.error("setPlayerOrder: Invalid arguments", { gameId, players });
+    throw new HttpsError("invalid-argument", "gameId and players are required");
+  }
+
+  try {
+    const gameRef = db.collection("games").doc(gameId);
+    const gameDoc = await gameRef.get();
+    if (!gameDoc.exists) {
+      console.error("setPlayerOrder: Game not found", gameId);
+      throw new HttpsError("not-found", "Game not found");
+    }
+
+    const gameData = gameDoc.data() as InitialGame;
+
+    if (gameData.host !== userId) {
+      console.error("setPlayerOrder: User is not host", { userId, host: gameData.host });
+      throw new HttpsError("permission-denied", "Only the host can reorder players");
+    }
+
+    if (gameData.status !== "gathering-players") {
+      console.error("setPlayerOrder: Game not in gathering-players state", gameData.status);
+      throw new HttpsError("failed-precondition", "Players can only be reordered before the game starts");
+    }
+
+    const originalPlayers = gameData.players;
+    if (players.length !== originalPlayers.length || !players.every((p) => originalPlayers.includes(p))) {
+      console.error("setPlayerOrder: Players array mismatch", { players, originalPlayers });
+      throw new HttpsError("invalid-argument", "Players array must contain the same players as the game");
+    }
+
+    await gameRef.update({ players });
+
+    console.info("setPlayerOrder: Player order updated", { gameId, players });
+    return { success: true };
+  } catch (error) {
+    console.error("setPlayerOrder: Unexpected error", error);
+    if (error instanceof HttpsError) {
+      throw error;
+    }
+    throw new HttpsError("internal", "Failed to set player order");
+  }
+});
+

--- a/hooks/useSetPlayerOrder.ts
+++ b/hooks/useSetPlayerOrder.ts
@@ -1,0 +1,41 @@
+import { functions } from '@/config/firebase';
+import { SetPlayerOrderRequest, SetPlayerOrderResponse } from '@/functions/src/setPlayerOrder';
+import { httpsCallable } from 'firebase/functions';
+import { useState } from 'react';
+import { Alert } from '@/ui/components/AlertBanner';
+
+const setPlayerOrderFunction = httpsCallable<SetPlayerOrderRequest, SetPlayerOrderResponse>(functions, 'setPlayerOrder');
+
+export function useSetPlayerOrder() {
+  const [isSettingOrder, setIsSettingOrder] = useState(false);
+
+  const setPlayerOrder = async (gameId: string, players: string[]) => {
+    if (!gameId || !players) {
+      Alert.error({ message: 'Invalid arguments' });
+      return;
+    }
+    try {
+      setIsSettingOrder(true);
+      await setPlayerOrderFunction({ gameId, players });
+    } catch (error: any) {
+      console.error('useSetPlayerOrder: Error setting player order:', error);
+      if (error.code === 'functions/permission-denied') {
+        Alert.error({ message: 'Only the host can reorder players.' });
+      } else if (error.code === 'functions/failed-precondition') {
+        Alert.error({ message: 'Players can only be reordered before the game starts.' });
+      } else if (error.code === 'functions/unauthenticated') {
+        Alert.error({ message: 'Please sign in to reorder players.' });
+      } else if (error.code === 'functions/not-found') {
+        Alert.error({ message: 'Game not found.' });
+      } else if (error.code === 'functions/invalid-argument') {
+        Alert.error({ message: 'Invalid request.' });
+      } else {
+        Alert.error({ message: 'Failed to reorder players.' });
+      }
+    } finally {
+      setIsSettingOrder(false);
+    }
+  };
+
+  return { setPlayerOrder, isSettingOrder };
+}


### PR DESCRIPTION
## Summary
- add a cloud function to update player order
- export new function in index
- add hook for calling setPlayerOrder from the app

## Testing
- `yarn functions:build`
- `yarn functions:lint`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_687e96af0914832a850a022334ec6604