### PR TITLE
Use Reanimated for animations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.*
 app-example
 .env
 .vercel
+
+# Firebase emulator data
+emulator-data/

--- a/app/playground.tsx
+++ b/app/playground.tsx
@@ -4,7 +4,7 @@ import {
 } from "@/ui/components/AnimatableCardDeck";
 import { Button, ScreenContainer } from "@/ui/elements";
 import React, { useRef } from "react";
-import { Animated } from "react-native";
+import { useSharedValue } from "react-native-reanimated";
 
 export default function PlaygroundScreen() {
   const cardRef = useRef<AnimatableCardRef>(null);
@@ -13,13 +13,13 @@ export default function PlaygroundScreen() {
     <ScreenContainer>
       <AnimatableCard
         cardWidth={80}
-        x={new Animated.Value(100)}
-        y={new Animated.Value(100)}
-        rotation={new Animated.Value(0)}
-        backOpacity={new Animated.Value(1)}
-        faceOpacity={new Animated.Value(0)}
-        rotateY={new Animated.Value(0)}
-        scale={new Animated.Value(1)}
+        x={useSharedValue(100)}
+        y={useSharedValue(100)}
+        rotation={useSharedValue(0)}
+        backOpacity={useSharedValue(1)}
+        faceOpacity={useSharedValue(0)}
+        rotateY={useSharedValue(0)}
+        scale={useSharedValue(1)}
         ref={cardRef}
         zIndex={0}
       />

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-dom": "19.0.0",
     "react-native": "0.79.5",
     "react-native-gesture-handler": "~2.24.0",
-    "react-native-reanimated": "~3.17.4",
+    "react-native-reanimated": "^3.19.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "functions"
   ],
   "scripts": {
-    "dev": "concurrently \"yarn start\" \"firebase emulators:start\" \"yarn functions:build:watch\"",
+    "dev": "concurrently \"yarn start\" \"yarn emulators:start\" \"yarn functions:build:watch\"",
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
@@ -14,6 +14,7 @@
     "build": "expo export --platform web",
     "lint": "expo lint",
     "test": "tsc",
+    "emulators:start": "firebase emulators:start --import=./emulator-data --export-on-exit",
     "functions:build": "yarn workspace functions build",
     "functions:build:watch": "yarn workspace functions build:watch",
     "functions:lint": "yarn workspace functions lint"

--- a/ui/components/AnimatableCardDeck.tsx
+++ b/ui/components/AnimatableCardDeck.tsx
@@ -6,50 +6,25 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { Animated, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
+import Animated, {
+  SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
 
 export interface AnimatableCardDeckRef {
   getCards(): readonly AnimatedCard[];
 }
 
-export interface AnimatedCard extends CardAnimatableProps, AnimatableCardRef {
-  // no extra props
-}
+export interface AnimatedCard extends CardAnimatableProps, AnimatableCardRef {}
 
 interface AnimatableCardDeckProps {
   cardWidth: number;
   numCards?: number;
 }
 
-/**
- * A deck of cards that can be animated however you want.
- * ```tsx
- * const deckRef = useRef<AnimatableCardDeckRef>(null);
- * <AnimatableCardDeck ref={deckRef} cardWidth={60} />
- * ```
- *
- * You can then use the ref to access the cards and control them individually:
- * ```tsx
- * const cards = deckRef.current?.getCards();
- * if (!cards) return;
- * // Set the value of the first four cards
- * cards[0].setValue("10H");
- * cards[1].setValue("10D");
- * cards[2].setValue("10C");
- * cards[3].setValue("10S");
- * ```
- *
- * You can also access the animated values of each card to animate them as you please:
- * ```tsx
- * const cards = deckRef.current?.getCards();
- * if (!cards) return;
- * Animated.stagger(10, cards.map((card) => Animated.timing(card.x, {
- *   toValue: 100,
- *   duration: 20,
- *   useNativeDriver: true,
- * }))).start();
- * ```
- */
 export const AnimatableCardDeck = React.forwardRef<
   AnimatableCardDeckRef,
   AnimatableCardDeckProps
@@ -87,13 +62,13 @@ export const AnimatableCardDeck = React.forwardRef<
 });
 
 export interface CardAnimatableProps {
-  x: Animated.Value;
-  y: Animated.Value;
-  rotation: Animated.Value;
-  backOpacity: Animated.Value;
-  faceOpacity: Animated.Value;
-  rotateY: Animated.Value;
-  scale: Animated.Value;
+  x: SharedValue<number>;
+  y: SharedValue<number>;
+  rotation: SharedValue<number>;
+  backOpacity: SharedValue<number>;
+  faceOpacity: SharedValue<number>;
+  rotateY: SharedValue<number>;
+  scale: SharedValue<number>;
 }
 
 interface AnimatableCardProps extends CardAnimatableProps {
@@ -130,11 +105,37 @@ export const AnimatableCard = React.forwardRef<
   const width = cardWidth;
   const height = cardWidth * 1.4;
 
+  // Animated styles
+  const animatedStyle = useAnimatedStyle(
+    () => ({
+      zIndex,
+      width,
+      height,
+      position: "absolute",
+      transform: [
+        { translateX: -width / 2 },
+        { translateY: -height / 2 },
+        { translateX: x.value },
+        { translateY: y.value },
+        { rotate: `${rotation.value}deg` },
+        { rotateY: `${rotateY.value}deg` },
+        { scale: scale.value },
+      ],
+    }),
+    [zIndex, width, height]
+  );
+
+  const backOpacityStyle = useAnimatedStyle(() => ({
+    opacity: backOpacity.value,
+  }));
+  const faceOpacityStyle = useAnimatedStyle(() => ({
+    opacity: faceOpacity.value,
+  }));
+
   const flip = useCallback(
     function flip() {
       const wasFaceDown = isFaceDownRef.current;
       isFaceDownRef.current = !isFaceDownRef.current;
-
       return cardFlipAnimation(
         { rotateY, backOpacity, faceOpacity },
         wasFaceDown
@@ -177,41 +178,11 @@ export const AnimatableCard = React.forwardRef<
   );
 
   return (
-    <Animated.View
-      style={{
-        zIndex,
-        width,
-        height,
-        position: "absolute",
-        transform: [
-          { translateX: "-50%" },
-          { translateY: "-50%" },
-          { translateX: x },
-          { translateY: y },
-          {
-            rotate: rotation.interpolate({
-              inputRange: [0, 360],
-              outputRange: ["0deg", "360deg"],
-            }),
-          },
-          {
-            rotateY: rotateY.interpolate({
-              inputRange: [0, 90, 180],
-              outputRange: ["0deg", "90deg", "0deg"],
-            }),
-          },
-          { scale: scale },
-        ],
-      }}
-    >
-      <Animated.View
-        style={[{ opacity: backOpacity }, StyleSheet.absoluteFill]}
-      >
+    <Animated.View style={animatedStyle}>
+      <Animated.View style={[backOpacityStyle, StyleSheet.absoluteFill]}>
         <CardBack width={width} height={height} />
       </Animated.View>
-      <Animated.View
-        style={[{ opacity: faceOpacity }, StyleSheet.absoluteFill]}
-      >
+      <Animated.View style={[faceOpacityStyle, StyleSheet.absoluteFill]}>
         {value && <Card cardId={value} width={width} height={height} />}
       </Animated.View>
     </Animated.View>
@@ -224,13 +195,13 @@ function createInitialCardDeck(
   return Object.freeze(
     Array.from({ length: numCards }, () =>
       Object.freeze({
-        x: new Animated.Value(0),
-        y: new Animated.Value(0),
-        rotation: new Animated.Value(Math.floor(Math.random() * 4)),
-        backOpacity: new Animated.Value(1),
-        faceOpacity: new Animated.Value(0),
-        rotateY: new Animated.Value(0),
-        scale: new Animated.Value(1),
+        x: useSharedValue(0),
+        y: useSharedValue(0),
+        rotation: useSharedValue(Math.floor(Math.random() * 4)),
+        backOpacity: useSharedValue(1),
+        faceOpacity: useSharedValue(0),
+        rotateY: useSharedValue(0),
+        scale: useSharedValue(1),
       })
     )
   );
@@ -259,30 +230,13 @@ function cardFlipAnimation(
   return new Promise<void>((resolve) => {
     const finalBackOpacity = wasFaceDown ? 0 : 1;
     const finalFaceOpacity = wasFaceDown ? 1 : 0;
-
-    Animated.sequence([
-      Animated.timing(rotateY, {
-        toValue: 90,
-        duration: 150,
-        useNativeDriver: true,
-      }),
-      Animated.parallel([
-        Animated.timing(backOpacity, {
-          toValue: finalBackOpacity,
-          duration: 0,
-          useNativeDriver: true,
-        }),
-        Animated.timing(faceOpacity, {
-          toValue: finalFaceOpacity,
-          duration: 0,
-          useNativeDriver: true,
-        }),
-      ]),
-      Animated.timing(rotateY, {
-        toValue: 0,
-        duration: 150,
-        useNativeDriver: true,
-      }),
-    ]).start(() => resolve());
+    // Animate rotateY to 90, swap opacities, then animate back to 0
+    rotateY.value = withTiming(90, { duration: 150 }, () => {
+      backOpacity.value = finalBackOpacity;
+      faceOpacity.value = finalFaceOpacity;
+      rotateY.value = withTiming(0, { duration: 150 }, () => {
+        resolve();
+      });
+    });
   });
 }

--- a/ui/components/AnimatableCardDeck.tsx
+++ b/ui/components/AnimatableCardDeck.tsx
@@ -176,8 +176,6 @@ export const AnimatableCard = React.forwardRef<
     [setValue, setZIndex, ensureFaceUp, ensureFaceDown, flip]
   );
 
-  const perspective = useRef(new Animated.Value(1000)).current;
-
   return (
     <Animated.View
       style={{
@@ -185,7 +183,6 @@ export const AnimatableCard = React.forwardRef<
         width,
         height,
         position: "absolute",
-        // perspective: perspective,
         transform: [
           { translateX: "-50%" },
           { translateY: "-50%" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7163,10 +7163,10 @@ react-native-is-edge-to-edge@1.1.7, react-native-is-edge-to-edge@^1.1.6, react-n
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz#28947688f9fafd584e73a4f935ea9603bd9b1939"
   integrity sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==
 
-react-native-reanimated@~3.17.4:
-  version "3.17.5"
-  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz#09ebe3c9e3379c5c0c588b7ab30c131ea29b60f0"
-  integrity sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==
+react-native-reanimated@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/react-native-reanimated/-/react-native-reanimated-3.19.0.tgz#3413dd8865eec549642a4a63cd4e5354a25043c7"
+  integrity sha512-FNfqLuPuVHsW9KcsZtnJqIPlMQvuySnSFJXgSt9fVDPqptbSUkiAF6MthUwd4Mxt05hCRcbV+T65CENgVS5iCg==
   dependencies:
     "@babel/plugin-transform-arrow-functions" "^7.0.0-0"
     "@babel/plugin-transform-class-properties" "^7.0.0-0"


### PR DESCRIPTION
- Adds an updated hit deck animation where the original card will move to the left a bit prior to moving the hit card onto it
- Converts the animations to be powered by react-native-reanimtated because they have a better api for getting the animated value's current values.