### PR TITLE
Fix duplicate share link in iMessage

### DIFF
--- a/hooks/useShare.ts
+++ b/hooks/useShare.ts
@@ -11,7 +11,7 @@ export function useShare() {
     try {
       const url = Linking.createURL(`/games/${gameId}`);
       await Share.share({
-        message: `Join my Modi game!\n${url}`,
+        message: 'Join my Modi game!',
         url,
       });
     } catch (err) {


### PR DESCRIPTION
## Summary
- avoid including the game link twice in share messages

## Testing
- `npx tsc --listFiles`

------
https://chatgpt.com/codex/tasks/task_e_688199263ec0832a8de98012a472aadf