### PR TITLE
Fix life counts on right side of board

### DIFF
--- a/ui/screens/Game/components/CardTable/LiveCounts.tsx
+++ b/ui/screens/Game/components/CardTable/LiveCounts.tsx
@@ -23,6 +23,11 @@ export function LiveCounts() {
             position: "absolute",
             top: playerPositions[playerId]?.y,
             left: playerPositions[playerId]?.x,
+            transform: [
+              playerPositions[playerId]?.x > 0
+                ? { translateX: "-100%" }
+                : undefined,
+            ].filter(Boolean) as any,
           }}
         >
           <PlayerLiveCount


### PR DESCRIPTION
## Summary
- adjust live count position so it shifts left for players on the right side

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6882baf13488832aa9a34a88e9067c39