### PR TITLE
Add play again lobby feature

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -28,4 +28,5 @@ export { startGame } from "./startGame";
 export { stick } from "./stick";
 export { swapCard } from "./swapCard";
 export { setPlayerOrder } from "./setPlayerOrder";
+export { playAgain } from "./playAgain";
 

--- a/functions/src/playAgain.ts
+++ b/functions/src/playAgain.ts
@@ -1,0 +1,112 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+import { createAndStoreAction, createPlayerJoinedAction } from "./actionUtils";
+import { Game, GameStatus, InitialGame } from "./types";
+import { getUsername } from "./util";
+
+const db = getFirestore();
+
+export interface PlayAgainRequest {
+  gameId: string;
+}
+
+export interface PlayAgainResponse {
+  gameId: string;
+}
+
+export const playAgain = onCall<PlayAgainRequest, Promise<PlayAgainResponse>>(async (request) => {
+  const userId = request.auth?.uid;
+  if (!userId) {
+    console.error("PlayAgain: User is not authenticated");
+    throw new HttpsError("unauthenticated", "User is not authenticated");
+  }
+
+  const { gameId } = request.data;
+  if (!gameId) {
+    console.error("PlayAgain: Game ID is required");
+    throw new HttpsError("invalid-argument", "Game ID is required");
+  }
+
+  const gameRef = db.collection("games").doc(gameId);
+  const username = await getUsername(userId);
+  let nextGameId = await generateGameId();
+
+  await db.runTransaction(async (tx) => {
+    const gameDoc = await tx.get(gameRef);
+    if (!gameDoc.exists) {
+      console.error("PlayAgain: Game not found", gameId);
+      throw new HttpsError("not-found", "Game not found");
+    }
+
+    const gameData = gameDoc.data() as Game & { nextGameId?: string };
+    if (gameData.status !== GameStatus.Ended) {
+      console.error("PlayAgain: Game is not ended", gameData.status);
+      throw new HttpsError("failed-precondition", "Game has not ended");
+    }
+
+    nextGameId = gameData.nextGameId || nextGameId;
+
+    const nextGameRef = db.collection("games").doc(nextGameId);
+
+    if (!gameData.nextGameId) {
+      const newGame: InitialGame = {
+        gameId: nextGameId,
+        status: GameStatus.GatheringPlayers,
+        players: [userId],
+        host: userId,
+        usernames: { [userId]: username },
+        initialLives: gameData.initialLives,
+      };
+      tx.set(nextGameRef, newGame);
+      tx.update(gameRef, { nextGameId });
+      return;
+    }
+
+    const nextGameDoc = await tx.get(nextGameRef);
+    if (!nextGameDoc.exists) {
+      console.error("PlayAgain: Next game not found", nextGameId);
+      throw new HttpsError("not-found", "Next game not found");
+    }
+
+    const nextGameData = nextGameDoc.data() as InitialGame;
+    if (nextGameData.status !== GameStatus.GatheringPlayers) {
+      console.error("PlayAgain: Next game already started", nextGameId);
+      throw new HttpsError(
+        "failed-precondition",
+        "Next game already started"
+      );
+    }
+
+    if (!nextGameData.players.includes(userId)) {
+      tx.update(nextGameRef, {
+        players: [...nextGameData.players, userId],
+        usernames: { ...nextGameData.usernames, [userId]: username },
+      });
+    }
+  });
+
+  const joinedAction = createPlayerJoinedAction(userId, username);
+  await createAndStoreAction(nextGameId, joinedAction);
+
+  console.info("PlayAgain: Player", userId, "joined next game", nextGameId);
+  return { gameId: nextGameId };
+});
+
+async function generateGameId() {
+  let newId: string;
+  let attempts = 0;
+  const maxAttempts = 10;
+
+  do {
+    newId = Math.floor(1000 + Math.random() * 9000).toString();
+    attempts++;
+  } while (await isGameIdExists(newId) && attempts < maxAttempts);
+
+  return newId;
+}
+
+async function isGameIdExists(gameId: string) {
+  const ref = db.collection("games").doc(gameId);
+  const doc = await ref.get();
+  return doc.exists;
+}

--- a/hooks/usePlayAgain.ts
+++ b/hooks/usePlayAgain.ts
@@ -1,0 +1,28 @@
+import { functions } from '@/config/firebase';
+import { PlayAgainRequest, PlayAgainResponse } from '@/functions/src/playAgain';
+import { useRouter } from 'expo-router';
+import { httpsCallable } from 'firebase/functions';
+import { useState } from 'react';
+import { Alert } from '@/ui/components/AlertBanner';
+
+const playAgainFunction = httpsCallable<PlayAgainRequest, PlayAgainResponse>(functions, 'playAgain');
+
+export function usePlayAgain() {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const playAgain = async (gameId: string) => {
+    try {
+      setIsLoading(true);
+      const result = await playAgainFunction({ gameId });
+      router.push(`/games/${result.data.gameId}`);
+    } catch (error) {
+      console.error('usePlayAgain: Error creating new game', error);
+      Alert.error({ message: 'Failed to start a new game. Please try again.' });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { playAgain, isPlayingAgain: isLoading };
+}

--- a/ui/screens/Game/PlayerControls.tsx
+++ b/ui/screens/Game/PlayerControls.tsx
@@ -8,6 +8,7 @@ import { DealCardsButton } from "./components/DealCardsButton";
 import { JoinGameButton } from "./components/JoinGameButton";
 import { LeaveGameButton } from "./components/LeaveGameButton";
 import { StartGameButton } from "./components/StartGameButton";
+import { PlayAgainButton } from "./components/PlayAgainButton";
 
 export function PlayerControls(props: { game: Game; currUserId: string }) {
   const { game, currUserId } = props;
@@ -35,7 +36,12 @@ export function PlayerControls(props: { game: Game; currUserId: string }) {
   }
 
   if (game.status === "ended") {
-    return <LeaveGameButton variant="large" />;
+    return (
+      <>
+        <LeaveGameButton variant="large" />
+        <PlayAgainButton gameId={game.gameId} />
+      </>
+    );
   }
 
   if (game.roundState === "pre-deal") {

--- a/ui/screens/Game/components/PlayAgainButton.tsx
+++ b/ui/screens/Game/components/PlayAgainButton.tsx
@@ -1,0 +1,20 @@
+import { usePlayAgain } from '@/hooks/usePlayAgain';
+import { Button, Text } from '@/ui/elements';
+import React from 'react';
+
+export function PlayAgainButton(props: { gameId: string }) {
+  const { gameId } = props;
+  const { playAgain, isPlayingAgain } = usePlayAgain();
+
+  return (
+    <Button
+      color="blue"
+      onPress={() => playAgain(gameId)}
+      loading={isPlayingAgain}
+      fullWidth
+      style={{ flexDirection: 'row', gap: 8 }}
+    >
+      <Text>Play Again</Text>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `playAgain` cloud function
- hook for playing again and button component
- show Play Again button when game ends
- handle concurrent Play Again requests in a transaction

## Testing
- `yarn test`
- `npx tsc -p .`
- `npx tsc -p functions/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6883d8828d78832a9b4d4a4ae7cb5727