### PR TITLE
RFC for preview api deployments

### DIFF
--- a/.github/workflows/preview-sync.yml
+++ b/.github/workflows/preview-sync.yml
@@ -56,8 +56,15 @@ jobs:
           for i in {1..120}; do
             resp=$(curl -sS -H "$AUTH" -H "$ACC" \
               "${API_BASE}/pipelines/${HEROKU_PIPELINE_ID}/review-apps")
-            app_id=$(echo "$resp" | jq -r ".[] | select(.pr_number == ${PR_NUMBER}) | .app.id" | head -n1)
-            status=$(echo "$resp" | jq -r ".[] | select(.pr_number == ${PR_NUMBER}) | .status" | head -n1)
+            # Ensure response is an array before attempting to index
+            if echo "$resp" | jq -e 'type=="array"' >/dev/null 2>&1; then
+              app_id=$(echo "$resp" | jq -r --arg pr "$PR_NUMBER" 'map(select((.pr_number|tostring) == $pr)) | (.[0].app.id // empty)')
+              status=$(echo "$resp" | jq -r --arg pr "$PR_NUMBER" 'map(select((.pr_number|tostring) == $pr)) | (.[0].status // empty)')
+            else
+              echo "::warning::Unexpected Heroku response (not an array). Raw response: $resp"
+              app_id=""
+              status=""
+            fi
             echo "Heroku review app status: app_id='${app_id:-}', status='${status:-}' (attempt $i)"
             if [ -n "${app_id:-}" ] && [ "$status" = "created" ]; then
               break


### PR DESCRIPTION
Adds a GitHub Actions workflow to create synchronized preview environments for monorepo PRs, linking Vercel frontend deployments to ephemeral Heroku API Review Apps.

This PR introduces a new GitHub Actions workflow (`.github/workflows/preview-sync.yml`) that automatically deploys Vercel frontend previews for pull requests. These Vercel deployments are configured to point to a corresponding ephemeral Heroku Review App (for the `api/` subdirectory) by setting the `EXPO_PUBLIC_API_BASE_URL` environment variable. This ensures that frontend and API changes can be tested together in a dedicated preview environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-d39dacad-1bd6-46f7-8375-91f33ef9583c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d39dacad-1bd6-46f7-8375-91f33ef9583c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

