### PR TITLE
Handle failed lobby joins without leaving join screen

### DIFF
--- a/ui/screens/JoinLobby/Base.tsx
+++ b/ui/screens/JoinLobby/Base.tsx
@@ -14,11 +14,15 @@ export interface JoinLobbyScreenProps {
   isValidatingLobbyId: boolean;
   validationError?: string;
   isLobbyIdInvalid: boolean;
+  lobbyId: string;
+  onLobbyIdChange: (lobbyId: string) => void;
   onLobbyIdSet: (lobbyId: string) => void;
   onCancel: () => void;
 }
 const JoinLobbyScreenBase: React.FC<JoinLobbyScreenProps> = ({
   onLobbyIdSet,
+  lobbyId,
+  onLobbyIdChange,
   isValidatingLobbyId,
   isLobbyIdInvalid,
   validationError,
@@ -54,7 +58,13 @@ const JoinLobbyScreenBase: React.FC<JoinLobbyScreenProps> = ({
         <TextInput
           style={{ fontSize: 24 }}
           placeholder="Game PIN"
-          onChangeText={(text) => text.length === 4 && onLobbyIdSet(text)}
+          value={lobbyId}
+          onChangeText={(text) => {
+            onLobbyIdChange(text);
+            if (text.length === 4) {
+              onLobbyIdSet(text);
+            }
+          }}
           autoFocus
           keyboardType="number-pad"
         />

--- a/ui/screens/JoinLobby/Provider.tsx
+++ b/ui/screens/JoinLobby/Provider.tsx
@@ -1,12 +1,14 @@
 import { useJoinLobby } from "@/hooks/useJoinLobby";
 import { useRouter } from "expo-router";
-import React, { createContext } from "react";
+import React, { createContext, useState } from "react";
 import { JoinLobbyScreenProps } from "./Base";
 
 const defaultContextValue: JoinLobbyScreenProps = {
   isLobbyIdInvalid: false,
   isValidatingLobbyId: false,
   validationError: undefined,
+  lobbyId: "",
+  onLobbyIdChange() {},
   onLobbyIdSet() {},
   onCancel() {},
 };
@@ -17,23 +19,48 @@ export const JoinLobbyContext =
 export default function JoinLobbyProvider(props: React.PropsWithChildren) {
   const router = useRouter();
   const { joinLobby, isJoining } = useJoinLobby();
+  const [validationError, setValidationError] = useState<string | undefined>();
+  const [lobbyId, setLobbyId] = useState("");
 
-  const handleLobbyIdSet = (lobbyId: string) => {
-    joinLobby(lobbyId).then(() => {
-      router.push(`/games/${lobbyId}`);
-    });
+  const handleLobbyIdChange = (value: string) => {
+    if (validationError) {
+      setValidationError(undefined);
+    }
+    setLobbyId(value);
+  };
+
+  const handleLobbyIdSet = async (nextLobbyId: string) => {
+    if (isJoining) {
+      return;
+    }
+
+    setValidationError(undefined);
+
+    const result = await joinLobby(nextLobbyId);
+
+    if (!result.success) {
+      setValidationError(result.errorMessage);
+      setLobbyId("");
+      return;
+    }
+
+    setLobbyId("");
   };
 
   const handleCancel = () => {
     router.replace("/");
+    setLobbyId("");
+    setValidationError(undefined);
   };
 
   return (
     <JoinLobbyContext.Provider
       value={{
         isValidatingLobbyId: isJoining,
-        validationError: undefined,
-        isLobbyIdInvalid: false, // This will be handled by the error state
+        validationError,
+        lobbyId,
+        onLobbyIdChange: handleLobbyIdChange,
+        isLobbyIdInvalid: Boolean(validationError), // This will be handled by the error state
         onLobbyIdSet: handleLobbyIdSet,
         onCancel: handleCancel,
       }}


### PR DESCRIPTION
## Summary
- keep the Join Lobby input controlled so it can be cleared after failed join attempts
- update useJoinLobby to return success metadata and show server-provided error messages in the alert banner
- preserve the Join Lobby screen while surfacing validation errors instead of navigating away on failure

## Testing
- yarn lint *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_690ad85754a0832a92b0fd317b3a7652