### PR TITLE
Add lobby settings menu for starting lives

### DIFF
--- a/api/src/handlers/UpdateGameSettings/index.ts
+++ b/api/src/handlers/UpdateGameSettings/index.ts
@@ -1,0 +1,64 @@
+import type { AuthenticatedRequest } from "@/authenticate";
+import { db } from "@/firebase";
+import { GameStatus, type InitialGame } from "@/types";
+
+export interface UpdateGameSettingsRequest extends AuthenticatedRequest {
+  gameId: string;
+  initialLives: number;
+}
+
+export interface UpdateGameSettingsResponse {
+  success: boolean;
+  initialLives: number;
+}
+
+export async function updateGameSettings({
+  userId,
+  gameId,
+  initialLives,
+}: UpdateGameSettingsRequest): Promise<UpdateGameSettingsResponse> {
+  if (!gameId) {
+    throw Object.assign(new Error("gameId is required"), { status: 400 });
+  }
+
+  if (typeof initialLives !== "number" || Number.isNaN(initialLives)) {
+    throw Object.assign(new Error("initialLives must be a number"), { status: 400 });
+  }
+
+  if (!Number.isInteger(initialLives)) {
+    throw Object.assign(new Error("initialLives must be an integer"), { status: 400 });
+  }
+
+  if (initialLives < 1 || initialLives > 10) {
+    throw Object.assign(new Error("initialLives must be between 1 and 10"), {
+      status: 400,
+    });
+  }
+
+  const gameRef = db.collection("games").doc(gameId);
+  const gameDoc = await gameRef.get();
+
+  if (!gameDoc.exists) {
+    throw Object.assign(new Error("Game not found"), { status: 404 });
+  }
+
+  const gameData = gameDoc.data() as InitialGame;
+
+  if (gameData.host !== userId) {
+    throw Object.assign(new Error("Only the host can update settings"), {
+      status: 403,
+    });
+  }
+
+  if (gameData.status !== GameStatus.GatheringPlayers) {
+    throw Object.assign(
+      new Error("Settings can only be changed before the game starts"),
+      { status: 412 }
+    );
+  }
+
+  await gameRef.update({ initialLives });
+
+  return { success: true, initialLives };
+}
+

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -12,6 +12,7 @@ import { setPlayerOrder } from "./handlers/SetPlayerOrder";
 import { startGame } from "./handlers/StartGame";
 import { stick } from "./handlers/Stick";
 import { swapCard } from "./handlers/SwapCard";
+import { updateGameSettings } from "./handlers/UpdateGameSettings";
 import { makeRequestHandler } from "./handlers/makeHandler";
 import { getLanIp } from "./utils/getLanIPAddress";
 
@@ -37,6 +38,7 @@ app.post('/games/:gameId/play-again', makeRequestHandler(playAgain));
 app.post('/games/:gameId/set-player-order', makeRequestHandler(setPlayerOrder));
 app.post('/games/:gameId/stick', makeRequestHandler(stick));
 app.post('/games/:gameId/swap', makeRequestHandler(swapCard));
+app.post('/games/:gameId/settings', makeRequestHandler(updateGameSettings));
 
 const port = parseInt(process.env.PORT || '3000', 10);
 const host = process.env.HOST || '0.0.0.0'; // Bind to all network interfaces

--- a/hooks/useUpdateGameSettings.ts
+++ b/hooks/useUpdateGameSettings.ts
@@ -1,0 +1,67 @@
+import { auth } from "@/config/firebase";
+import { Alert } from "@/ui/components/AlertBanner";
+import { useState } from "react";
+
+interface UpdateGameSettingsPayload {
+  initialLives: number;
+}
+
+interface UpdateGameSettingsResponse {
+  success: boolean;
+  initialLives: number;
+}
+
+async function updateGameSettingsApi(
+  gameId: string,
+  payload: UpdateGameSettingsPayload
+): Promise<UpdateGameSettingsResponse> {
+  const response = await fetch(
+    `${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/settings`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${await auth.currentUser?.getIdToken()}`,
+      },
+      body: JSON.stringify(payload),
+    }
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      text || `Failed to update game settings: ${response.statusText}`
+    );
+  }
+
+  return response.json();
+}
+
+export function useUpdateGameSettings() {
+  const [isUpdatingSettings, setIsUpdatingSettings] = useState(false);
+
+  const updateSettings = async (
+    gameId: string,
+    payload: UpdateGameSettingsPayload
+  ): Promise<number | null> => {
+    if (!gameId) {
+      Alert.error({ message: "Invalid game ID" });
+      return null;
+    }
+
+    try {
+      setIsUpdatingSettings(true);
+      const result = await updateGameSettingsApi(gameId, payload);
+      return result.initialLives;
+    } catch (error) {
+      console.error("useUpdateGameSettings: Error updating settings", error);
+      Alert.error({ message: "Failed to update game settings." });
+      return null;
+    } finally {
+      setIsUpdatingSettings(false);
+    }
+  };
+
+  return { updateSettings, isUpdatingSettings };
+}
+

--- a/ui/elements/Icon/index.tsx
+++ b/ui/elements/Icon/index.tsx
@@ -24,6 +24,7 @@ const iconNameMap = {
   "checkmark-circle": "checkmark-circle",
   warning: "warning",
   "information-circle": "information-circle",
+  settings: "settings-sharp",
 } satisfies Record<string, IoniconIconName>;
 
 type IconName = keyof typeof iconNameMap;

--- a/ui/screens/Game/components/GameSettingsButton.tsx
+++ b/ui/screens/Game/components/GameSettingsButton.tsx
@@ -1,0 +1,158 @@
+import { GameStatus } from "@/api/src/types";
+import { useUserId } from "@/providers/Auth";
+import { useUpdateGameSettings } from "@/hooks/useUpdateGameSettings";
+import { Alert } from "@/ui/components/AlertBanner";
+import { Button, Container, Icon, Text, TextInput } from "@/ui/elements";
+import { colors } from "@/ui/styles";
+import React, { useCallback, useEffect, useState } from "react";
+import { Modal, TouchableOpacity } from "react-native";
+
+import { useCurrentGame } from "../PlayingContext";
+
+export function GameSettingsButton() {
+  const { game } = useCurrentGame();
+  const userId = useUserId();
+  const { updateSettings, isUpdatingSettings } = useUpdateGameSettings();
+  const [isVisible, setIsVisible] = useState(false);
+  const [startingLives, setStartingLives] = useState(String(game.initialLives));
+
+  useEffect(() => {
+    if (!isVisible) {
+      setStartingLives(String(game.initialLives));
+    }
+  }, [game.initialLives, isVisible]);
+
+  const isHostWaitingForPlayers =
+    game.status === GameStatus.GatheringPlayers && game.host === userId;
+
+  const handleOpen = useCallback(() => {
+    setStartingLives(String(game.initialLives));
+    setIsVisible(true);
+  }, [game.initialLives]);
+
+  const handleClose = useCallback(() => {
+    setIsVisible(false);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    const parsedLives = Number(startingLives);
+
+    if (!Number.isInteger(parsedLives)) {
+      Alert.error({ message: "Starting lives must be a whole number." });
+      return;
+    }
+
+    if (parsedLives < 1 || parsedLives > 10) {
+      Alert.error({
+        message: "Starting lives must be between 1 and 10.",
+      });
+      return;
+    }
+
+    const result = await updateSettings(game.gameId, {
+      initialLives: parsedLives,
+    });
+
+    if (result !== null) {
+      Alert.success({
+        message: `Starting lives updated to ${result}.`,
+      });
+      setIsVisible(false);
+    }
+  }, [game.gameId, startingLives, updateSettings]);
+
+  const handleChange = useCallback((value: string) => {
+    const digitsOnly = value.replace(/[^0-9]/g, "");
+    setStartingLives(digitsOnly);
+  }, []);
+
+  if (!isHostWaitingForPlayers) {
+    return null;
+  }
+
+  return (
+    <>
+      <TouchableOpacity
+        accessibilityLabel="Open game settings"
+        accessibilityRole="button"
+        onPress={handleOpen}
+        style={{
+          padding: 8,
+          borderRadius: 24,
+          backgroundColor: "rgba(0, 0, 0, 0.15)",
+        }}
+        hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
+      >
+        <Icon name="settings" size={28} color="white" />
+      </TouchableOpacity>
+
+      <Modal
+        visible={isVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={handleClose}
+      >
+        <Container
+          style={{
+            flex: 1,
+            backgroundColor: "rgba(0, 0, 0, 0.6)",
+            justifyContent: "center",
+            alignItems: "center",
+            padding: 24,
+          }}
+        >
+          <Container
+            style={{
+              width: "100%",
+              maxWidth: 360,
+              backgroundColor: colors.white,
+              borderRadius: 20,
+              padding: 24,
+              gap: 20,
+            }}
+          >
+            <Text size={24} color="darkText">
+              Game Settings
+            </Text>
+
+            <Container style={{ gap: 12 }}>
+              <Text size={18} color="darkText">
+                Starting lives
+              </Text>
+              <Text size={14} color="lightText">
+                Everyone in the game will begin with this many lives.
+              </Text>
+              <TextInput
+                keyboardType="number-pad"
+                value={startingLives}
+                onChangeText={handleChange}
+                style={{
+                  alignSelf: "center",
+                  width: 120,
+                }}
+                maxLength={2}
+              />
+            </Container>
+
+            <Container style={{ flexDirection: "row", gap: 12 }}>
+              <Button
+                title="Cancel"
+                color="gray"
+                fullWidth
+                onPress={handleClose}
+              />
+              <Button
+                title="Save"
+                color="lightGreen"
+                fullWidth
+                onPress={handleSave}
+                loading={isUpdatingSettings}
+              />
+            </Container>
+          </Container>
+        </Container>
+      </Modal>
+    </>
+  );
+}
+

--- a/ui/screens/Game/index.tsx
+++ b/ui/screens/Game/index.tsx
@@ -13,6 +13,7 @@ import { WinnerInfo } from "./components/WinnerInfo";
 import { useGame } from "./hooks/useGame";
 import { PlayerControls } from "./PlayerControls";
 import { PlayingProvider } from "./PlayingContext";
+import { GameSettingsButton } from "./components/GameSettingsButton";
 
 const GameScreen: React.FC = () => {
   // get the game id from the url
@@ -32,8 +33,18 @@ const GameScreen: React.FC = () => {
                 paddingTop: 28,
                 paddingVertical: 32,
                 alignItems: "center",
+                width: "100%",
               }}
             >
+              <Container
+                style={{
+                  position: "absolute",
+                  top: 28,
+                  right: 24,
+                }}
+              >
+                <GameSettingsButton />
+              </Container>
               <ShareGameInfo />
               <WinnerInfo />
             </Container>


### PR DESCRIPTION
## Summary
- add an authenticated API endpoint so hosts can update the starting lives before the game begins
- provide a hook and lobby settings modal that lets the host change the starting lives while gathering players
- register a settings icon for the new host controls

## Testing
- yarn lint *(fails: workspace not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_690ade29f4f8832a954a45dd708168ad