### PR TITLE
Improve start game error messaging

### DIFF
--- a/hooks/useStartGame.ts
+++ b/hooks/useStartGame.ts
@@ -47,8 +47,12 @@ export function useStartGame() {
       
     } catch (error: any) {
       console.error("useStartGame: Error starting game:", error);
-      
-      Alert.error({ message: 'Failed to start game. Please try again.' });
+      const errorMessage = typeof error?.message === 'string' ? error.message : '';
+      const message = errorMessage.includes('Need at least 2 players')
+        ? 'You need at least 2 players in order to start the game.'
+        : errorMessage || 'Failed to start game. Please try again.';
+
+      Alert.error({ message });
     } finally {
       setIsStartingGame(false);
     }


### PR DESCRIPTION
### Motivation
- The lobby showed a vague error when starting a game with only the host; the backend already returns a clear "Need at least 2 players" error and the UI should surface that to the user.

### Description
- Update `hooks/useStartGame.ts` to inspect the thrown error message and display a specific alert `You need at least 2 players in order to start the game.` when the backend indicates too few players, otherwise fall back to the server-provided message or the generic message.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972f1c06a14832a8e4fa7721b26cc67)