### PR TITLE
Fix cross-platform local IP detection for API URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "concurrently \"yarn start\" \"yarn emulators:start\" \"yarn api:dev\"",
     "dev:prod": "EXPO_PUBLIC_CONNECT_TO_PROD=true concurrently \"yarn start\" \"yarn api:dev:prod\"",
-    "start": "EXPO_PUBLIC_API_BASE_URL=http://$(ipconfig getifaddr en0):3000 expo start",
+    "start": "EXPO_PUBLIC_API_BASE_URL=http://$(node scripts/get-local-ip.js):3000 expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",

--- a/scripts/get-local-ip.js
+++ b/scripts/get-local-ip.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform script to get the local network IP address.
+ * Works on macOS, Linux, and Windows.
+ */
+const os = require('os');
+
+function getLocalIP() {
+  const interfaces = os.networkInterfaces();
+  
+  // Common interface names across platforms
+  const interfaceNames = [
+    'en0',      // macOS WiFi
+    'en1',      // macOS Ethernet
+    'eth0',     // Linux
+    'wlan0',    // Linux WiFi
+    'Ethernet', // Windows
+    'Wi-Fi',    // Windows
+  ];
+  
+  // Try known interface names first
+  for (const name of interfaceNames) {
+    const iface = interfaces[name];
+    if (iface) {
+      const ipv4 = iface.find(addr => addr.family === 'IPv4' && !addr.internal);
+      if (ipv4) {
+        return ipv4.address;
+      }
+    }
+  }
+  
+  // Fallback: search all interfaces for a non-internal IPv4 address
+  for (const [name, addrs] of Object.entries(interfaces)) {
+    const ipv4 = addrs?.find(addr => addr.family === 'IPv4' && !addr.internal);
+    if (ipv4) {
+      return ipv4.address;
+    }
+  }
+  
+  // Last resort: localhost
+  return 'localhost';
+}
+
+console.log(getLocalIP());


### PR DESCRIPTION
## Summary

Replaces the macOS-specific `ipconfig getifaddr en0` command with a cross-platform Node.js script that works on macOS, Linux, and Windows.

## Problem

The `start` script used a macOS-only command:
```bash
EXPO_PUBLIC_API_BASE_URL=http://$(ipconfig getifaddr en0):3000 expo start
```

On Linux/Windows, this fails silently and `EXPO_PUBLIC_API_BASE_URL` becomes `undefined`, causing API calls to fail.

## Solution

Added `scripts/get-local-ip.js` that:
1. Checks common interface names (`en0`, `eth0`, `wlan0`, etc.)
2. Falls back to searching all interfaces for non-internal IPv4
3. Last resort: returns `localhost`

```bash
# Now works on all platforms
EXPO_PUBLIC_API_BASE_URL=http://$(node scripts/get-local-ip.js):3000 expo start
```

## Testing

```bash
# macOS
node scripts/get-local-ip.js  # Returns e.g., 192.168.1.100

# Linux  
node scripts/get-local-ip.js  # Returns e.g., 172.31.51.110
```

Fixes #47