### PR TITLE
feat: Auto-resolve API URL for Vercel previews

### DIFF
--- a/config/api.ts
+++ b/config/api.ts
@@ -1,0 +1,28 @@
+/**
+ * API Configuration
+ * 
+ * Automatically resolves the API base URL:
+ * - Production: uses EXPO_PUBLIC_API_BASE_URL or falls back to production URL
+ * - Vercel Preview (PR): constructs Heroku review app URL from PR number
+ * - Local dev: uses EXPO_PUBLIC_API_BASE_URL (typically localhost)
+ */
+
+const PRODUCTION_API_URL = 'https://api.modi.app';
+
+function getApiBaseUrl(): string {
+  // Check for explicit env var first (local dev, production override)
+  if (process.env.EXPO_PUBLIC_API_BASE_URL) {
+    return process.env.EXPO_PUBLIC_API_BASE_URL;
+  }
+
+  // Vercel preview builds: construct Heroku review app URL
+  const prNumber = process.env.VERCEL_GIT_PULL_REQUEST_ID;
+  if (prNumber) {
+    return `https://modi-api-pr-${prNumber}.herokuapp.com`;
+  }
+
+  // Fallback to production
+  return PRODUCTION_API_URL;
+}
+
+export const API_BASE_URL = getApiBaseUrl();

--- a/hooks/useCreateGame.ts
+++ b/hooks/useCreateGame.ts
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from '@/config/firebase';
 import { Alert } from '@/ui/components/AlertBanner';
 import { useRouter } from 'expo-router';
@@ -6,7 +7,7 @@ import { useState } from 'react';
 type CreateGameResponse = { gameId: string };
 
 async function createGameFunction() {
-  const response = await fetch(`${process.env.EXPO_PUBLIC_API_BASE_URL}/games`, {
+  const response = await fetch(`${API_BASE_URL}/games`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/hooks/useDealCards.ts
+++ b/hooks/useDealCards.ts
@@ -1,10 +1,11 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from '@/config/firebase';
 import { Alert } from '@/ui/components/AlertBanner';
 import { useCurrentGame } from '@/ui/screens/Game/PlayingContext';
 import { useState } from 'react';
 
 async function dealCardsApi(gameId: string) {
-  const response = await fetch(`${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/deal`, {
+  const response = await fetch(`${API_BASE_URL}/games/${gameId}/deal`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/hooks/useEndRound.ts
+++ b/hooks/useEndRound.ts
@@ -1,10 +1,11 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from '@/config/firebase';
 import { Alert } from '@/ui/components/AlertBanner';
 import { useCurrentGame } from '@/ui/screens/Game/PlayingContext';
 import { useState } from 'react';
 
 async function endRoundApi(gameId: string) {
-  const response = await fetch(`${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/end-round`, {
+  const response = await fetch(`${API_BASE_URL}/games/${gameId}/end-round`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/hooks/useJoinLobby.ts
+++ b/hooks/useJoinLobby.ts
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from '@/config/firebase';
 import { Alert } from '@/ui/components/AlertBanner';
 import { usePathname, useRouter } from 'expo-router';
@@ -9,7 +10,7 @@ type JoinLobbyResult =
 
 async function joinGameApi(gameId: string) {
   const response = await fetch(
-    `${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/join`,
+    `${API_BASE_URL}/games/${gameId}/join`,
     {
       method: 'POST',
       headers: {

--- a/hooks/useLeaveGame.ts
+++ b/hooks/useLeaveGame.ts
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from '@/config/firebase';
 import { Alert } from '@/ui/components/AlertBanner';
 import { useCurrentGame } from '@/ui/screens/Game/PlayingContext';
@@ -5,7 +6,7 @@ import { useRouter } from 'expo-router';
 import { useState } from 'react';
 
 async function leaveGameApi(gameId: string) {
-  const response = await fetch(`${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/leave`, {
+  const response = await fetch(`${API_BASE_URL}/games/${gameId}/leave`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/hooks/usePlayAgain.ts
+++ b/hooks/usePlayAgain.ts
@@ -1,10 +1,11 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from '@/config/firebase';
 import { Alert } from '@/ui/components/AlertBanner';
 import { useRouter } from 'expo-router';
 import { useState } from 'react';
 
 async function playAgainApi(gameId: string) {
-  const response = await fetch(`${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/play-again`, {
+  const response = await fetch(`${API_BASE_URL}/games/${gameId}/play-again`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/hooks/useSetPlayerOrder.ts
+++ b/hooks/useSetPlayerOrder.ts
@@ -1,9 +1,10 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from '@/config/firebase';
 import { Alert } from '@/ui/components/AlertBanner';
 import { useState } from 'react';
 
 async function setPlayerOrderApi(gameId: string, players: string[]) {
-  const response = await fetch(`${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/set-player-order`, {
+  const response = await fetch(`${API_BASE_URL}/games/${gameId}/set-player-order`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/hooks/useStartGame.ts
+++ b/hooks/useStartGame.ts
@@ -1,9 +1,10 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from '@/config/firebase';
 import { Alert } from '@/ui/components/AlertBanner';
 import { useState } from 'react';
 
 async function startGameApi(gameId: string) {
-  const response = await fetch(`${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/start`, {
+  const response = await fetch(`${API_BASE_URL}/games/${gameId}/start`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/hooks/useStick.ts
+++ b/hooks/useStick.ts
@@ -1,10 +1,11 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from '@/config/firebase';
 import { Alert } from '@/ui/components/AlertBanner';
 import { useCurrentGame } from '@/ui/screens/Game/PlayingContext';
 import { useState } from 'react';
 
 async function stickApi(gameId: string) {
-  const response = await fetch(`${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/stick`, {
+  const response = await fetch(`${API_BASE_URL}/games/${gameId}/stick`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/hooks/useSwapCards.ts
+++ b/hooks/useSwapCards.ts
@@ -1,10 +1,11 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from '@/config/firebase';
 import { Alert } from '@/ui/components/AlertBanner';
 import { useCurrentGame } from '@/ui/screens/Game/PlayingContext';
 import { useState } from 'react';
 
 async function swapCardApi(gameId: string) {
-  const response = await fetch(`${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/swap`, {
+  const response = await fetch(`${API_BASE_URL}/games/${gameId}/swap`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/hooks/useUpdateGameSettings.ts
+++ b/hooks/useUpdateGameSettings.ts
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from '@/config/api';
 import { auth } from "@/config/firebase";
 import { Alert } from "@/ui/components/AlertBanner";
 import { useState } from "react";
@@ -10,7 +11,7 @@ interface UpdateGameSettingsParams {
 async function updateGameSettingsApi(params: UpdateGameSettingsParams) {
   const { gameId, ...body } = params;
   const response = await fetch(
-    `${process.env.EXPO_PUBLIC_API_BASE_URL}/games/${gameId}/settings`,
+    `${API_BASE_URL}/games/${gameId}/settings`,
     {
       method: "PATCH",
       headers: {

--- a/hooks/useWarmUpServer.ts
+++ b/hooks/useWarmUpServer.ts
@@ -1,3 +1,4 @@
+import { API_BASE_URL } from '@/config/api';
 import { useEffect, useRef } from "react";
 
 export function useWarmUpServer() {
@@ -6,7 +7,7 @@ export function useWarmUpServer() {
     if (calledWarmUpServer.current) return;
     calledWarmUpServer.current = true;
     console.log('Warming up server');
-    fetch(`${process.env.EXPO_PUBLIC_API_BASE_URL}/`).then(() => {
+    fetch(`${API_BASE_URL}/`).then(() => {
       console.log('Server warmed up');
     }).catch((error) => {
       console.error('Failed to warm up server', error);


### PR DESCRIPTION
## Summary
Automatically connects Vercel preview builds to the correct Heroku review app.

## How it works
- Added `config/api.ts` that dynamically resolves the API base URL
- On Vercel preview builds, uses `VERCEL_GIT_PULL_REQUEST_ID` to construct the Heroku review app URL
- Pattern: `https://modi-api-pr-{PR_NUMBER}.herokuapp.com`
- Falls back to production URL when not in preview context

## Changes
- New `config/api.ts` - centralized API URL resolution
- Updated all hooks to import `API_BASE_URL` from config instead of using `process.env` directly

## Also configured
- Set `base_name: modi-api-pr` on Heroku pipeline so review apps get predictable URLs

## Testing
Open a PR with API changes → both Vercel and Heroku previews should connect automatically.