### PR TITLE
ci: add GitHub Action for auto-deploying Firebase Functions

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -1,0 +1,44 @@
+name: Deploy Firebase Functions
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'functions/**'
+      - '.github/workflows/deploy-functions.yml'
+
+jobs:
+  deploy:
+    name: Deploy Functions
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'yarn'
+          cache-dependency-path: functions/yarn.lock
+
+      - name: Install root dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install functions dependencies
+        working-directory: functions
+        run: yarn install --frozen-lockfile
+
+      - name: Build functions
+        working-directory: functions
+        run: yarn build
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy to Firebase
+        run: firebase deploy --only functions --token "${{ secrets.FIREBASE_TOKEN }}"
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a GitHub Action workflow that automatically deploys Firebase Functions when changes are pushed to main.

## Trigger
- Pushes to `main` branch
- Only when files in `functions/` directory change

## Requirements
- Uses existing `FIREBASE_TOKEN` secret (from `firebase login:ci`)

## What it does
1. Checks out code
2. Sets up Node.js 18
3. Installs dependencies (root + functions)
4. Builds functions
5. Deploys to Firebase